### PR TITLE
Function and route to get all data docs given Net Model + Cluster ID

### DIFF
--- a/backend/api-spec.json
+++ b/backend/api-spec.json
@@ -125,7 +125,7 @@
                 "clusterID": {
                   "example": "any"
                 },
-                "type": {
+                "model": {
                   "example": "any"
                 }
               }
@@ -314,6 +314,126 @@
       "get": {
         "description": "",
         "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/clusters/netModelData/{modelName}/{modelCost}/dates/{minDate}/{maxDate}/": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "modelName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "modelCost",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "minDate",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "maxDate",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/clusters/netModelData/{modelName}/{modelCost}/min/{minDate}": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "modelName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "modelCost",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "minDate",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/clusters/netModelData/{modelName}/{modelCost}/max/{maxDate}": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "modelName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "modelCost",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "maxDate",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/clusters/netModelData/{modelName}/{modelCost}": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "modelName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "modelCost",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK"

--- a/backend/src/customers/models.ts
+++ b/backend/src/customers/models.ts
@@ -1,5 +1,18 @@
 import { getModelForClass, prop } from "@typegoose/typegoose";
 
+class Model {
+  constructor(name: string, cost: number) {
+    this.name = name;
+    this.cost = cost;
+  }
+
+  @prop()
+  public name!: string;
+  
+  @prop()
+  public cost!: number;
+}
+
 class Data {
   constructor(netID: string, date: Date, water_collected: number) {
     this.netID = netID;
@@ -18,16 +31,16 @@ class Data {
 }
 
 class Net {
-  constructor(clusterID: string, type: string) {
+  constructor(clusterID: string, model: Model) {
     this.clusterID = clusterID;
-    this.type = type;
+    this.model = model;
   }
 
   @prop()
   public clusterID!: string;
 
   @prop()
-  public type!: string;
+  public model!: Model;
 }
 
 class Cluster {
@@ -42,5 +55,6 @@ class Cluster {
 const ClusterModel = getModelForClass(Cluster);
 const NetModel = getModelForClass(Net);
 const DataModel = getModelForClass(Data);
+const ModelModel = getModelForClass(Model);
 
-export { Cluster, ClusterModel, Net, NetModel, Data, DataModel };
+export { Cluster, ClusterModel, Net, NetModel, Data, DataModel, Model, ModelModel };

--- a/backend/src/customers/views.ts
+++ b/backend/src/customers/views.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import mongoose from "mongoose";
 import DocController from "./controllers";
+import { Model } from "./models";
 
 // Note: we should use a try/catch to choose successJson or errorJson for responses
 // this has been left out of this snippet for brevity
@@ -33,8 +34,8 @@ docRouter.get("/nets/:id", async (req, res) => {
 });
 
 docRouter.post("/nets/", async (req, res) => {
-  const { clusterID, type } = req.body;
-  res.status(201).send( successJson(await DocController.insertNet(clusterID, type)));
+  const { clusterID, model } = req.body;
+  res.status(201).send( successJson(await DocController.insertNet(clusterID, model)));
 });
 
 docRouter.delete("/net/delete/:id", async (req, res) => {
@@ -62,7 +63,7 @@ docRouter.delete("/data/delete/:id", async (req, res) => {
 });
 // NOTE: END OF TEMPORARY ROUTES
 
-const clusterIds = ["65258f01ba4c14948edd4526", "65258d88899b7e221c1d33eb"] // NOTE: temp hardcoded list of clusterIDs for testing
+const clusterIds = ["65258f01ba4c14948edd4526", "6528685b77174a7928f4ef6d"] // NOTE: temp hardcoded list of clusterIDs for testing
 docRouter.get("/clusterData/dates/:minDate/:maxDate/", async (req, res) => {
   let minDate = new Date(req.params.minDate);
   let maxDate = new Date(req.params.maxDate);
@@ -93,6 +94,50 @@ docRouter.get("/clusterData/", async (req, res) => {
   res
     .status(200)
     .send(successJson(await DocController.getAllDocsByClusterIDs(clusterIds, minDate, maxDate)));
+});
+
+docRouter.get("/netModelData/:modelName/:modelCost/dates/:minDate/:maxDate/", async (req, res) => {
+  let minDate = new Date(req.params.minDate);
+  let maxDate = new Date(req.params.maxDate);
+  let name = req.params.modelName;
+  let cost = Number(req.params.modelCost);
+  let model = new Model(name, cost);
+  res
+    .status(200)
+    .send(successJson(await DocController.getAllDocsByModelAndClusterIDs(clusterIds, minDate, maxDate, model)));
+});
+
+docRouter.get("/netModelData/:modelName/:modelCost/min/:minDate", async (req, res) => {
+  let minDate = new Date(req.params.minDate);
+  let maxDate = new Date(new Date().toJSON().slice(0, 10));
+  let name = req.params.modelName;
+  let cost = Number(req.params.modelCost);
+  let model = new Model(name, cost);
+  res
+    .status(200)
+    .send(successJson(await DocController.getAllDocsByModelAndClusterIDs(clusterIds, minDate, maxDate, model)));
+});
+
+docRouter.get("/netModelData/:modelName/:modelCost/max/:maxDate", async (req, res) => {
+  let minDate = new Date("2023-01-01");
+  let maxDate = new Date(req.params.maxDate);
+  let name = req.params.modelName;
+  let cost = Number(req.params.modelCost);
+  let model = new Model(name, cost);
+  res
+    .status(200)
+    .send(successJson(await DocController.getAllDocsByModelAndClusterIDs(clusterIds, minDate, maxDate, model)));
+});
+
+docRouter.get("/netModelData/:modelName/:modelCost", async (req, res) => {
+  let minDate = new Date("2023-01-01");
+  let maxDate = new Date(new Date().toJSON().slice(0, 10));
+  let name = req.params.modelName;
+  let cost = Number(req.params.modelCost);
+  let model = new Model(name, cost);
+  res
+    .status(200)
+    .send(successJson(await DocController.getAllDocsByModelAndClusterIDs(clusterIds, minDate, maxDate, model)));
 });
 
 export default docRouter;


### PR DESCRIPTION
## Overview

Created a function and route that gets all data documents given a net model and a list of cluster IDs. It also takes in two optional parameters minDate and maxDate which specifies the earliest or latest date to query.

## Changes Made

I created a Model Class with fields name (string) and cost (number) and updated Net Class to reflect changes in the database schema. I recycled parts of my code from last week's ticket of creating a function and route to get all data docs given a list of cluster IDs. I created a helper function that is shared by the two functions in order to minimize repeated code. For now, a net model is passed into the routes by params modelName and modelCost.

## Test Coverage

1) checkout branch model-query-func
2) Use Postman or swagger http://localhost:8000/api-docs to create clusters, nets, and data docs (NOTE: list clusterIds is currently hardcoded in views.ts for testing purpose, so after creating a cluster you want to test, copy the id and update clusterIds in views.ts)
3) Use the routes to get data docs given net model (modelName and modelCost) and cluster IDs (4 different routes: given both minDate and maxDate, given only minDate, given only maxDate, given neither minDate nor maxDate)